### PR TITLE
Fix incorrect container command

### DIFF
--- a/charts/lupa/templates/deployment.yaml
+++ b/charts/lupa/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
+          args:
             - --config=/etc/conf/collector-config.yaml
           {{- with .Values.env }}
           env:


### PR DESCRIPTION
K8s `command` overrides the image `ENTRYPOINT`. We don't need to do this as we only need to pass an argument.