### PR TITLE
Fix collector configmap formatting

### DIFF
--- a/charts/lupa/templates/configmap.yaml
+++ b/charts/lupa/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "lupa.labels" . | nindent 4 }}
 data:
   collector-config.yaml: |
-    {{- toYaml .Values.collectorConfig | nindent 4 }}
+    {{- .Values.collectorConfig | nindent 4 }}

--- a/charts/lupa/values.yaml
+++ b/charts/lupa/values.yaml
@@ -67,7 +67,7 @@ env:
   API_PORT: "8080"
   # ES_ENDPOINT: "http://elasticsearch:9200"
 
-collectorConfig:
+collectorConfig: |
   receivers:
     otlp:
       protocols:


### PR DESCRIPTION
Currently, the collector config is formatted as yaml before being used in the configmap template.
This creates some formatting issues as the `toYaml` function does not format it as expected by the collector (and as written by the user). Passing the config as string instead of yaml ensures correct formatting.

values.yaml:
```
receivers:
  otlp:
    protocols:
      grpc:
      http:
processors:
  batch:
exporters:
  elasticsearch:
    endpoints: ["http://elasticsearch:9200/"]
service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [elasticsearch]
```


Current (notice the missing keys):
```
Data
====
collector-config.yaml:
----
exporters:
  elasticsearch:
    endpoints:
    - http://elasticsearch:9200/
processors: {}
receivers:
  otlp:
    protocols: {}
service:
  pipelines:
    traces:
      exporters:
      - elasticsearch
      processors:
      - batch
      receivers:
      - otlp
```

After the change:
```
Data
====
collector-config.yaml:
----
receivers:
  otlp:
    protocols:
      grpc:
      http:
processors:
  batch:
exporters:
  elasticsearch:
    endpoints: ["http://elasticsearch:9200/"]
service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [elasticsearch]
```