### PR TITLE
refactor: rename repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs) to get started.
 Once Helm has been set up correctly, add the repo as follows:
 
 ```sh
-helm repo add teletrace https://teletrace.github.io/teletrace-helm-charts/
+helm repo add teletrace https://teletrace.github.io/helm-charts/
 ```
 
 If you had already added this repo earlier, run `helm repo update` to retrieve

--- a/charts/teletrace/Chart.yaml
+++ b/charts/teletrace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: teletrace
 description: Teletrace Helm chart for Kubernetes
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "v0.6.0"


### PR DESCRIPTION
Rename repository from `teletrace-helm-charts` to `helm-charts`. It is the more common naming convention when the helm-charts repository is under an organization with the same name.