### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+Teletrace project.
+
+- [Reporting a Bug](#reporting-a-bug)
+- [Disclosure Policy](#disclosure-policy)
+- [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The Teletrace team and community take all security bugs in
+Teletrace seriously. Thank you for improving the security of
+Teletrace. We appreciate your efforts and responsible disclosure and
+will make every effort to acknowledge your contributions.
+
+Report security bugs by emailing `oss-security@cisco.com`.
+
+The lead maintainer will acknowledge your email within 48 hours, and will send a
+more detailed response within 48 hours indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
+  released as quickly as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
Based on the Cisco OSS template repository:
https://github.com/teletrace/.github/blob/main/docs/SECURITY.md